### PR TITLE
Added example timezone override

### DIFF
--- a/scheduler-service.yml
+++ b/scheduler-service.yml
@@ -4,6 +4,7 @@ services:
     image: rayyanqcri/swarm-scheduler
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - /etc/timezone:/etc/timezone:ro
     environment:
       - DOCKER_URL=unix:///var/run/docker.sock
       - TZ=America/New_York

--- a/scheduler-service.yml
+++ b/scheduler-service.yml
@@ -6,6 +6,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - DOCKER_URL=unix:///var/run/docker.sock
+      - TZ=America/New_York
     configs:
       - source: crontab.v1
         target: crontab


### PR DESCRIPTION
Jobs were running in UTC, which would be fine if my local timezone didn't vary it's offset from UTC throughout the year, and if I didn't need stuff done at, for example, 7 PM localtime all year long - so after messing around and trying a few things to get it running in my local time, I finally figured out the fix, and thought it would be a very useful addition to the example scheduler-service.yml file.